### PR TITLE
preview suggestions before applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.0.8
+
+-   fix loading of results when hotspot detection was not executed
+-   preview suggestion patches before applying the suggestion
+
 ## 0.0.7
 
 -   automatically find installed DiscoPoP and HotspotDetection tools

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following table lists which discopop version is expected by a given version 
 
 | Extension Version | DiscoPoP Version |
 | ----------------- | ---------------- |
+| 0.0.8             | 3.2.0            |
 | 0.0.7             | 3.2.0            |
 | 0.0.6             | 3.2.0            |
 | 0.0.5             | 3.0.0            |
@@ -30,4 +31,4 @@ The following table lists which discopop version is expected by a given version 
 ## Known Issues
 
 -   CMake Configurations: Running the same tool multiple times creates some issues, e.g the same suggestions appearing multiple times. It usually helps to delete the build directory. A proposed fix is scheduled for DiscoPoP 4.0.0.
--   Updating from 0.0.5 to 0.0.6 crashes the extension if Script Configurations have been previously created, as the new version does not support them. We recommend to delete script configurations before updating the extension.
+-   Updating from 0.0.5 to newer versions crashes the extension if Script Configurations have been previously created, as all newer versions do not support them. We recommend to delete script configurations before updating the extension.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "An extension for the Parallelism Discovery tool DiscoPoP.",
     "author": "TU Darmstadt - Laboratory for Parallel Programming",
     "icon": "media/discopop_icon.png",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "publisher": "TUDarmstadt-LaboratoryforParallelProgramming",
     "repository": {
         "type": "git",

--- a/src/discoPoP/classes/Suggestion/Suggestion.ts
+++ b/src/discoPoP/classes/Suggestion/Suggestion.ts
@@ -12,10 +12,18 @@ export abstract class Suggestion {
     ) {}
 
     public getMappedStartLine(lineMapping: LineMapping): number {
+        if (!lineMapping) {
+            console.error('lineMapping is undefined, using original startLine')
+            return this.startLine
+        }
         return lineMapping.getMappedLineNr(this.fileId, this.startLine)
     }
 
     public getMappedEndLine(lineMapping: LineMapping): number {
+        if (!lineMapping) {
+            console.error('lineMapping is undefined, using original endLine')
+            return this.startLine
+        }
         return lineMapping.getMappedLineNr(this.fileId, this.endLine)
     }
 


### PR DESCRIPTION
- [x] first draft: open the relevant patch files and request confirmation before actually applying.


future steps:
- open a pretty diff view; requires to create a diff, i.e.:
  - apply the patch to a replica of the file,
  - show the diff between the changed replica and the current file
- "peek" instead of opening a new editor
- prettier confirmation dialogue (currently it takes fokus and does not allow browsing the changes without canceling and then having to press apply again)